### PR TITLE
Linkänderung beim Link Notfunk in den FAQ

### DIFF
--- a/docs/faq/link-list.md
+++ b/docs/faq/link-list.md
@@ -54,7 +54,7 @@ description: Hier findet ihr eine Sammlung von wichtigen / interessanten Links. 
 
 ## Notfunk
 
-- [Karte für Notfunk im Ortsverband DARC](https://www.darc.de/der-club/referate/notfunk/funkamateure/notfunk-im-ortsverband/notfunk-im-ortsverband-karte/): Die Übersichtskarte für den Notfunk im Ortsband des DARC
+- [Karte für Notfunk im Ortsverband DARC](https://www.darc.de/der-club/referate/notfunk/funkamateure/notfunk-im-ortsverband/notfunk-im-ortsverband-karte/): Die Übersichtskarte für den Notfunk in den Ortsverbänden des DARC
 
 ---
 

--- a/docs/faq/link-list.md
+++ b/docs/faq/link-list.md
@@ -54,7 +54,7 @@ description: Hier findet ihr eine Sammlung von wichtigen / interessanten Links. 
 
 ## Notfunk
 
-- [Notfunkkarte DARC](https://www.darc.de/der-club/referate/notfunk/referat/notfunkkarte/): Die offiziele Notfunkkarte vom DARC
+- [Karte für Notfunk im Ortsverband DARC](https://www.darc.de/der-club/referate/notfunk/funkamateure/notfunk-im-ortsverband/notfunk-im-ortsverband-karte/): Die Übersichtskarte für den Notfunk im Ortsband des DARC
 
 ---
 


### PR DESCRIPTION
Beim Durchklicken der Links in den FAQ ist mir aufgefallen, dass der unterste Link zur Notfunkkarte ins Leere führt.

Bisheriger Link:

https://www.darc.de/der-club/referate/notfunk/referat/notfunkkarte/

![image](https://github.com/user-attachments/assets/1ecb10f3-5475-4c84-8a19-d14b25bba09b)

Neuer Link:

https://www.darc.de/der-club/referate/notfunk/funkamateure/notfunk-im-ortsverband/notfunk-im-ortsverband-karte/
