### PR TITLE
Add München details for Frühlingsfest 2026

### DIFF
--- a/docs/aktivitaeten/2026-04-25-Fruehlingsfest-2026.md
+++ b/docs/aktivitaeten/2026-04-25-Fruehlingsfest-2026.md
@@ -17,3 +17,7 @@ Am 25.04.2026 findet das Frühlingsfest statt! Wie immer sind alle aufgerufen, d
 ## Kassel
 
 Die Draussenfunker sind beim Funk.Tag Kassel mit einem eigenen Stand vertreten und kombinieren dies mit einem Community-Treffen. Kommt bei uns am Stand vorbei und sagt Hallo. Voraussichtlich wird es eine Kurzwellenstation im Park vor der Messehalle geben, so dass eine gemeinsame POTA-Aktivierung problemlos ohne eigenes Equipment möglich ist. Oder man bringt seine Flohmarktfunde direkt on air. Wir freuen uns auf euch!
+
+## München
+
+Die Draussenfunker in und um München treffen sich am 25.04.2026 um 10:00 Uhr zum Frühlingsfest im Landschaftspark Hachinger Tal (POTA-Referenz DE-0546). Der Park befindet sich zwischen Neubiberg und Unterhaching auf dem ehemaligen Militärflugplatz gleich neben der Bundeswehruniversität. Als Treffpunkt dient der am westlichen Ende der Landebahn gelegene Pavillon beim Beachvolleyballplatz. Die Grünflächen im Park bieten viel Platz für Antennen aller Art. Parkmöglichkeiten sind unter anderem  "An der Hachinger Haid" zu finden. Mit der S-Bahn ist der Treffpunkt im Park über die Haltestelle "Unterhaching" auch fußläufig gut zu erreichen.


### PR DESCRIPTION
Added details about the Frühlingsfest 2026 in München, including location and meeting point.